### PR TITLE
Changes for a more faithful comparison

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ crunchy = "0.2.1"
 # This feature deactivates bounds checks in the solver.
 unchecked_indexing = []
 
+default = ["unchecked_indexing"]
+
 [lib]
 name = "sudoku"
 crate-type = ["dylib"]

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -91,6 +91,19 @@ fn shuffle(b: &mut test::Bencher) {
 }
 
 #[bench]
+fn from_bytes(b: &mut test::Bencher) {
+    let sudokus = (0..1000)
+        .map(|_| Sudoku::generate_unique().to_bytes())
+        .collect::<Vec<_>>();
+
+    b.iter(||
+        for &sudoku in &sudokus {
+            let _ = Sudoku::from_bytes(sudoku).unwrap();
+        }
+    )
+}
+
+#[bench]
 fn parse_line(b: &mut test::Bencher) {
     let sudokus = (0..1000)
         .map(|_| Sudoku::generate_unique().to_str_line())

--- a/src/board/sudoku.rs
+++ b/src/board/sudoku.rs
@@ -245,7 +245,7 @@ impl Sudoku {
     /// Creates a sudoku from a byte array.
     /// All numbers must be below 10. Empty cells are denoted by 0, clues by the numbers 1-9.
     pub fn from_bytes(bytes: [u8; N_CELLS]) -> Result<Sudoku, ()> {
-        match bytes.iter().all(|&byte| byte <= 9) {
+        match bytes.iter().fold(true, |valid, &byte| valid & (byte <= 9)) {
             true => Ok(Sudoku(bytes)),
             false => Err(()),
         }

--- a/src/board/sudoku.rs
+++ b/src/board/sudoku.rs
@@ -275,7 +275,7 @@ impl Sudoku {
         for (cell, &ch) in grid.iter_mut().zip(chars) {
             match ch {
                 b'_' | b'.' => *cell = 0,
-                b'0'...b'9' => *cell = ch - b'0',
+                b'0'..=b'9' => *cell = ch - b'0',
                 // space ends sudoku before grid is filled
                 b' ' | b'\t' => return Err(LineParseError::NotEnoughCells(i)),
                 _ => {
@@ -298,7 +298,7 @@ impl Sudoku {
                 // delimiters, end of sudoku
                 b'\t' | b' ' | b'\r' | b'\n' | b';' | b',' => (),
                 // valid cell entry => too long
-                b'_' | b'.' | b'0'...b'9' => return Err(LineParseError::TooManyCells),
+                b'_' | b'.' | b'0'..=b'9' => return Err(LineParseError::TooManyCells),
                 // any other char can not be part of sudoku
                 // without having both length and character wrong
                 // treat like comment, but with missing delimiter
@@ -399,7 +399,7 @@ impl Sudoku {
                         // comment separator
                         ' ' | '\t' => break,
                         // valid entry, line too long
-                        '1'...'9' | '_' | '.' | '0' => {
+                        '1'..='9' | '_' | '.' | '0' => {
                             return Err(BlockParseError::InvalidLineLength(n_line_sud))
                         }
                         // invalid entry, interpret as comment but enforce separation
@@ -429,7 +429,7 @@ impl Sudoku {
                 let cell = n_line_sud * 9 + n_col_sud;
                 match ch {
                     '_' | '.' => grid[cell as usize] = 0,
-                    '0'...'9' => grid[cell as usize] = ch as u8 - b'0',
+                    '0'..='9' => grid[cell as usize] = ch as u8 - b'0',
                     _ => {
                         return Err(BlockParseError::InvalidEntry(InvalidEntry {
                             cell: cell as u8,

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -46,7 +46,7 @@ impl SudokuGenerator {
         loop {
             match stack.len() {
                 0 => break Ok(()),
-                1...4 => self.insert_entries_singly(stack)?,
+                1..=4 => self.insert_entries_singly(stack)?,
                 _ => self.batch_insert_entries(stack)?,
             }
         }

--- a/src/strategy/solver.rs
+++ b/src/strategy/solver.rs
@@ -391,7 +391,7 @@ impl StrategySolver {
         loop {
             match self.deduced_entries.len() - self.cell_poss_digits.next_deduced as usize {
                 0 => break Ok(()),
-                1...4 => self.insert_entries_singly(find_naked_singles)?,
+                1..=4 => self.insert_entries_singly(find_naked_singles)?,
                 _ => self.batch_insert_entries(find_naked_singles)?,
             }
         }


### PR DESCRIPTION
Hi there,

I noticed you included my rust solver into your benchmark. That's very cool. I thought you might not be familiar with Rust so I've looked for some performance gotchas.

* bounds checking
  The crate leaves bounds checking on array access on by default. This guarantees memory safety but impacts performance a bit. None of the C(++) solvers I saw did any of that so we can deactivate that by using the `unchecked_indexing` feature.
* sudoku parsing
  I didn't write the sudoku parser for performance and instead went for detailed error reporting. I imagined anything needing performance would keep an array of numbers 0-9 around and use `Sudoku::from_bytes` which only does some validation and is much faster.
  For very easy sudokus (such as your kaggle bench) this can be a significant part of the runtime. I've added a fast path for valid sudokus, bringing the time for parsing+validation down to 1/10 into the ~30-40ns range in my microbenchmarks (laptop cpu, i5-4310u). This should eliminate the bottleneck.

  By calling `CStr::as_str` you're also doing a utf8-validation which you're probably not doing for any of the other solvers, but that only takes on the order of ~10ns/sudoku so it's only a few % slower on very easy sudokus at most.
* compile for native cpu
  I don't think it's going to do much for this solver. There's only one loop I know of that is getting auto-vectorized and it's pretty short and accounts for only ~15% of the runtime. But just for completeness sake we can do it here as well by passing the flag `-C target-cpu=native` to rustc. I've added it to the `.cargo/config` file.